### PR TITLE
fix Northwind OrderGrid pdf invoice inline action

### DIFF
--- a/src/Serenity.Demo.Northwind/Modules/Order/OrderGrid.ts
+++ b/src/Serenity.Demo.Northwind/Modules/Order/OrderGrid.ts
@@ -83,7 +83,7 @@ export class OrderGrid<P={}> extends EntityGrid<OrderRow, P> {
             return;
 
         var item = this.itemAt(row);
-        let action = (e.target as HTMLElement)?.closest("inline-action")?.getAttribute("data-action");
+        let action = (e.target as HTMLElement)?.closest(".inline-action")?.getAttribute("data-action");
         if (action) {
             e.preventDefault();
             if (action == "inline-action") {


### PR DESCRIPTION
fix click event searching for "inline-action" element instead of a class.

fixes https://github.com/serenity-is/Serenity/issues/7058