### PR TITLE
Fix: MigrationUtil.EnsureDatabase - Replace `select *` with `select datname` in PostgreSQL database query

### DIFF
--- a/src/Serenity.Extensions/Modules/MigrationUtils/MigrationUtils.cs
+++ b/src/Serenity.Extensions/Modules/MigrationUtils/MigrationUtils.cs
@@ -185,7 +185,7 @@ END;", table, id, seq));
 
         if (isPostgres)
         {
-            databasesQuery = "select * from postgres.pg_catalog.pg_database where datname = @name";
+            databasesQuery = "select datname from postgres.pg_catalog.pg_database where datname = @name";
             createDatabaseQuery = "CREATE DATABASE \"{0}\"";
         }
         else if (isMySql)


### PR DESCRIPTION
Fixing a bug related to NspgSQL with not being able to get hashsum for aclitem[] column.

- Changed the query in the database check from `select *` to `select datname` to avoid unnecessary data retrieval and potential issues with data types.
- This fix addresses the issue where the application fails to handle all  columns returned by `select *` in the PostgreSQL pg_database table."